### PR TITLE
docker-composeのDB永続化設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Database Volumes
+/containers/postgres_volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:14.4-alpine
     restart: always
     volumes:
-      - ./containers/db:/docker-entrypoint-initdb.d
+      - ./containers/postgres_volume:/var/lib/postgresql/data
     ports:
       - 5433:5432
     environment:


### PR DESCRIPTION
コンテナを消すとDBの中身が消えてしまったので、docker-compose.ymlを編集してDB永続化を設定しました。
`/docker-entrypoint-initdb.d`はDB作成時にレコードを追加するファイルなので、永続化とは関係がないと思いました。