### PR TITLE
Feature/step11 タスクを作成日の降順にし、テスト

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -38,6 +38,13 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "削除されました"
   end
 
+  #
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+  def render_404
+    render file: 'public/404.html', status: 404, content_type: 'text/html'
+  end
+
   private
     def set_task
       @task = Task.find(params[:id])

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,8 +1,8 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %i[ show edit update destroy ]
-  
+
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order('created_at DESC')
   end
 
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -38,7 +38,6 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "削除されました"
   end
 
-  #
   rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
   def render_404

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[ show edit update destroy ]
 
   def index
-    @tasks = Task.all.order('created_at DESC')
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def show

--- a/config/database.yml
+++ b/config/database.yml
@@ -60,7 +60,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV['PG_DATABASE'] %>
+  database: app_test
   username: <%= ENV['PG_USER'] %>
   password: <%= ENV['PG_PASSWORD'] %>
   host: db

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :task do
+  factory :task, class: Task do
     name { "task name" }
     detail { "task detail" }
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :task do
-    name "task name"
-    detail "task detail"
+    name { "task name" }
+    detail { "task detail" }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] = 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/requests/tasks_request_spec.rb
+++ b/spec/requests/tasks_request_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe TasksController, type: :request do
+  describe '#index' do
+    let!(:task1) { create(:task, name:'task1', detail:'task detail1', created_at:'2022-08-23T12:00:00.000+09:00') }
+    let!(:task2) { create(:task, name:'task2', detail:'task detail2', created_at:'2022-08-15T12:00:00.000+09:00') }
+    let!(:task3) { create(:task, name:'task3', detail:'task detail3', created_at:'2022-08-22T12:00:00.000+09:00') }
+
+    it '200OK' do
+      get tasks_path
+      expect(response).to have_http_status 200
+    end
+
+    it 'be success' do
+      get tasks_path
+      expect(response).to be_successful
+    end
+
+    it '順序がタスクの作成日の降順となっていること' do
+      get tasks_path
+      expect(controller.instance_variable_get(:@tasks)).to eq [task1, task3, task2]
+    end
+  end
+end

--- a/spec/requests/tasks_request_spec.rb
+++ b/spec/requests/tasks_request_spec.rb
@@ -18,11 +18,20 @@ RSpec.describe TasksController, type: :request do
   end
 
   describe '#show' do
-    let!(:task) { create(:task) }
+    context 'When a task exists' do
+      let!(:task) { create(:task) }
 
-    it '200 OK' do
-      get task_path task
-      expect(response).to have_http_status 200
+      it '200 OK' do
+        get task_path task
+        expect(response).to have_http_status 200
+      end
+    end
+
+    context 'When a task does not exist' do
+      it '404 not found' do
+        get task_path 1
+        expect(response).to have_http_status 404
+      end
     end
   end
 
@@ -47,6 +56,7 @@ RSpec.describe TasksController, type: :request do
     it '302 redirect' do
       post tasks_path, params: { task: attributes_for(:task) }
       expect(response).to have_http_status 302
+      expect(response).to redirect_to Task.last
     end
   end
 
@@ -56,6 +66,7 @@ RSpec.describe TasksController, type: :request do
     it '302 redirect' do
       put task_path task, params: { task: attributes_for(:task, name:'update name', detail:'update detail') }
       expect(response).to have_http_status 302
+      expect(response).to redirect_to Task.last
     end
   end
 
@@ -65,6 +76,7 @@ RSpec.describe TasksController, type: :request do
     it '302 redirect' do
       delete task_path task
       expect(response).to have_http_status 302
+      expect(response).to redirect_to(tasks_path)
     end
   end
 end

--- a/spec/requests/tasks_request_spec.rb
+++ b/spec/requests/tasks_request_spec.rb
@@ -6,19 +6,65 @@ RSpec.describe TasksController, type: :request do
     let!(:task2) { create(:task, name:'task2', detail:'task detail2', created_at:'2022-08-15T12:00:00.000+09:00') }
     let!(:task3) { create(:task, name:'task3', detail:'task detail3', created_at:'2022-08-22T12:00:00.000+09:00') }
 
-    it '200OK' do
+    it '200 OK' do
       get tasks_path
       expect(response).to have_http_status 200
-    end
-
-    it 'be success' do
-      get tasks_path
-      expect(response).to be_successful
     end
 
     it '順序がタスクの作成日の降順となっていること' do
       get tasks_path
       expect(controller.instance_variable_get(:@tasks)).to eq [task1, task3, task2]
+    end
+  end
+
+  describe '#show' do
+    let!(:task) { create(:task) }
+
+    it '200 OK' do
+      get task_path task
+      expect(response).to have_http_status 200
+    end
+  end
+
+  describe '#new' do
+    it '200 OK' do
+      get new_task_path
+      expect(response).to be_successful
+      expect(response).to have_http_status 200
+    end
+  end
+
+  describe '#edit' do
+    let!(:task) { create(:task) }
+
+    it '200 OK' do
+      get edit_task_path task
+      expect(response).to have_http_status 200
+    end
+  end
+
+  describe '#create' do
+    it '302 redirect' do
+      post tasks_path, params: { task: attributes_for(:task) }
+      expect(response).to have_http_status 302
+    end
+  end
+
+  describe '#update' do
+    let!(:task) { create(:task) }
+
+    it '302 redirect' do
+      put task_path task, params: { task: attributes_for(:task, name:'update name', detail:'update detail') }
+      expect(response).to have_http_status 302
+    end
+  end
+
+  describe '#destroy' do
+    let!(:task) { create(:task) }
+
+    it '302 redirect' do
+      delete task_path task
+      expect(response).to have_http_status 302
     end
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class TasksControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get tasks_index_url
-    assert_response :success
-  end
-end


### PR DESCRIPTION
# 実装内容
* テストがdevelopment環境で実行されてしまうので、spec/rails_helper.rbを編集してdevelopment環境のdockerコンテナ内でもtest環境でテストが実行されるように変更
* テスト用のデータベースを追加
  * config/databese.ymlのtest環境時のデータベース名がdevelopment環境時のもの一緒になっていたので変更した
  * `rails db:create RAILS_ENV=test`, `rails db:migrate RAILS_ENV=test`を実行
* FactoryBotを使いテストデータを作成してrspecでタスクが作成日時の降順になっているかどうかのテストを実装
# 動作確認
* テスト時にテスト用データベースにつながることを確認
* テストが通ることを確認
# 特に共有すべきこと
* 基本的なことだけど、テスト実行時はtest環境になっているか、テスト用データベースが用意されているか、確認しなければいけない
# 参考資料
* [docker環境でrspecで403エラーが出た時の解決](https://zenn.dev/akhmgc/articles/5fa1ed2bc018e4)
# スクリーンショット
![スクリーンショット 2022-08-23 13 34 17](https://user-images.githubusercontent.com/54321883/186070452-26d4f4ca-ae32-4fea-968c-a60b095cc1a1.png)

